### PR TITLE
Avoid matching of '$gen_call' messages

### DIFF
--- a/src/easton_index.erl
+++ b/src/easton_index.erl
@@ -326,8 +326,10 @@ handle_call({cmd, C}, _From, #st{port = Port} = St) ->
     receive
         {Port, {data, Resp}} ->
             {reply, Resp, St};
-        Else ->
-            throw({error, Else})
+         {Port, Else} ->
+            throw({error, Else});
+         {'EXIT', Port, Reason} ->
+            throw({error, Reason})
     after ?TIMEOUT ->
             exit({timeout, C})
     end;


### PR DESCRIPTION
Previously any message received by easton_index process while it is
waiting for response from the port_command caused a failure. Since new
message was matching in receive statement. Even though it is not
originated from the port.

This commit fixes the issue by explicitly matching all
possible message formats we can receive from the port program.