### PR TITLE
Make compatible with spatialindex master

### DIFF
--- a/c_src/easton_index/io.hh
+++ b/c_src/easton_index/io.hh
@@ -22,7 +22,7 @@
 #include <leveldb/db.h>
 #include <leveldb/write_batch.h>
 #include <spatialindex/capi/sidx_api.h>
-#include <spatialindex/capi/CustomStorage.h>
+#include <spatialindex/capi/sidx_impl.h>
 
 #include "ei.h"
 


### PR DESCRIPTION
Master C API changed https://github.com/libspatialindex/libspatialindex/commit/e779efac79ede3a1cc710e72a1ead8bacbeb42ca

Specifically SpatialIndex.h where some types like `id_type` are defined,
is not included from sidx_config.h, which was in turn included from
sidx_api.h before. Not it is included from sidx_imp.h.

Also no need to inlucde CustomStorage.h individually as it is already
included by sidx_impl.h