### PR TITLE
Add new _geo_disk_size to get disk size information

### DIFF
--- a/src/easton_index.erl
+++ b/src/easton_index.erl
@@ -32,6 +32,7 @@
     doc_count/1,
     geom_count/1,
     os_pid/1,
+    disk_size/1,
 
     update/3,
     remove/2,
@@ -783,6 +784,15 @@ kill_cmd(OsPid) ->
 
 get_disk_size(Idx) ->
     IdxDir = gen_server:call(Idx, idx_dir, infinity),
+    disk_size_int(IdxDir).
+
+
+disk_size(IdxDir) ->
+    DiskSize = disk_size_int(IdxDir),
+    {ok, [{disk_size, DiskSize}]}.
+
+
+disk_size_int(IdxDir) ->
     Pattern0 = filename:join(IdxDir, "*"),
     Pattern = case Pattern0 of
         _ when is_binary(Pattern0) ->


### PR DESCRIPTION
Currently the only way to get the disk size information for hastings
index is to use the _geo_info endpoint. But using this endpoint
would
open databases along with hastings_index and easton processes.

This change adds a new end point _geo_disk_size to get the
disk size information without opening databases and indexes.
It works by scanning geo directory and summing up the file
sizes there.

Usage:
<dbname>/_design/<DDoc>/_geo_disk_size/<IndexName>

Example reply:
{
  "name": "_design/geodd/geoidx",
  "geo_index": {
    "disk_size": 9646
  }
}

There is also a companion hastings PR.

BugzID: 89995