### PR TITLE
Fix io.cc compile error in recent clang versions

### DIFF
--- a/c_src/easton_index/io.cc
+++ b/c_src/easton_index/io.cc
@@ -521,9 +521,8 @@ Writer::Writer()
 
 Writer::~Writer()
 {
-    if(ei_x_free(this->buff.get()) != 0) {
-        throw EastonException("Error destroying Writer buffer.");
-    }
+    ei_x_free(this->buff.get());
+
 }
 
 


### PR DESCRIPTION
Don't throw from ~Writer()

Recent builds on macos started failing because an exception is thrown from
`~Writer()`. Destructors have been switched to have the default flag of
`noexcept(true)` and so throwing stop compilation.

Instead of annotating with `noexcept(false)` don't raise the exception at all.
Erlang ei code doesn't even bother returning the error either:

https://github.com/erlang/otp/blob/1526eaead833b3bdcd3555a12e2af62c359e7868/lib/erl_interface/src/misc/ei_x_encode.c#L61-L68
