### PR TITLE
Acknowledge use of unstable C++ API

### DIFF
--- a/c_src/easton_index/geo.cc
+++ b/c_src/easton_index/geo.cc
@@ -15,6 +15,9 @@
 #include <string>
 #include <sstream>
 
+// Acknowledge use of unstable C++ API
+#define USE_UNSTABLE_GEOS_CPP_API
+
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/Polygon.h>


### PR DESCRIPTION
When compiling db.git, GEOS errors with
```
/usr/local/include/geos/geom/Geometry.h:26:3: error: "The GEOS C++ API is unstable, please use the C API instead" [-Werror,-W#warnings]
# warning "The GEOS C++ API is unstable, please use the C API instead"
  ^
/usr/local/include/geos/geom/Geometry.h:27:3: error: "HINT: #include geos_c.h" [-Werror,-W#warnings]
# warning "HINT: #include geos_c.h"
```
This PR defines `USE_UNSTABLE_GEOS_CPP_API` which will prevent this error.