### PR TITLE
Allow compiling when using deprecated API

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -13,7 +13,7 @@ end,
         ]}
     ]},
     {port_env, [
-        {"CXXFLAGS", "$CXXFLAGS -std=c++0x -g -Wall -Werror"},
+        {"CXXFLAGS", "$CXXFLAGS -std=c++0x -g -Wall -Werror -Wno-error=deprecated-declarations"},
         {"EXE_LDFLAGS",
             "$EXE_LDFLAGS -lCsMap -lspatialindex -lspatialindex_c -lgeos -lgeos_c -lleveldb"},
         {"EXE_LINK_TEMPLATE",


### PR DESCRIPTION
`db.git` fails to compile after the macOS upgrade. Since Geo is deprecated, add "-Wno-error=deprecated-declarations" to allow the code to compile.

See error logs:

```bash
Compiling /Users/jiahuili/src/db/src/easton/c_src/easton_index/command.cc
In file included from /Users/jiahuili/src/db/src/easton/c_src/easton_index/command.cc:16:
In file included from c_src/easton_index/command.hh:17:
In file included from c_src/easton_index/index.hh:17:
In file included from /usr/local/include/spatialindex/capi/sidx_api.h:34:
In file included from /usr/local/include/spatialindex/capi/sidx_config.h:56:
In file included from /usr/local/include/spatialindex/SpatialIndex.h:252:
/usr/local/include/spatialindex/MovingRegion.h:155:34: error: 'binary_function<SpatialIndex::MovingRegion::CrossPoint &, SpatialIndex::MovingRegion::CrossPoint &, bool>' is deprecated [-Werror,-Wdeprecated-declarations]
                        struct ascending: public std::binary_function<CrossPoint&, CrossPoint&, bool>
                                                      ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__functional/binary_function.h:24:29: note: 'binary_function<SpatialIndex::MovingRegion::CrossPoint &, SpatialIndex::MovingRegion::CrossPoint &, bool>' has been explicitly marked deprecated here
struct _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 binary_function
                            ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__config:825:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX11'
                                        ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__config:810:49: note: expanded from macro '_LIBCPP_DEPRECATED'
                                                ^
1 error generated.
ERROR: compile failed while processing /Users/jiahuili/src/db/src/easton: rebar_abort
make: *** [rebar_compile] Error 1
```